### PR TITLE
Fix incorrect declaration of randombytes() in tweetnacl.c

### DIFF
--- a/tweetnacl.c
+++ b/tweetnacl.c
@@ -7,7 +7,7 @@ typedef unsigned long u32;
 typedef unsigned long long u64;
 typedef long long i64;
 typedef i64 gf[16];
-extern void randombytes(u8 *,u64);
+extern void randombytes(u8 *, unsigned int);
 
 static const u8
   _0[16],


### PR DESCRIPTION
Declaring `randombytes()` with incorrect signature (`u64` for `length` in declaration vs `unsigned int` in definition) leads to incorrect type casting on some platforms (`armeabi-v7a` for instance, probably other 32-bit platforms as well), and as a result `fread()` from `/dev/urandom` might (depends on casting result) fail trying to read more than 0x7ffff000 bytes ([see notes section here](http://man7.org/linux/man-pages/man2/read.2.html)).

Also it might make more sense to swap 2nd and 3rd arguments to `fread` (size and nmemb) and check for the number of read elements. Current implementation should also work, so it's left as is.
